### PR TITLE
Add `xnat_link_data_directory` variable for XNAT role

### DIFF
--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -13,3 +13,4 @@ xnat_config_dir: "{{ xnat_home_dir }}/config"
 xnat_logs_dir: "{{ xnat_home_dir }}/logs"
 xnat_work_dir: "{{ xnat_home_dir }}/work"
 xnat_create_data_directory: true
+xnat_link_data_directory: true

--- a/roles/xnat/tasks/directories.yml
+++ b/roles/xnat/tasks/directories.yml
@@ -13,7 +13,7 @@
     src: "{{ xnat_web_server.storage_dir }}"
     dest: "{{ xnat_data_dir }}"
     state: link
-  when: xnat_create_data_directory and external_storage_drive is defined
+  when: xnat_link_data_directory and external_storage_drive is defined
 
 - name: "Ensure XNAT subdirectories exist"
   ansible.builtin.file:


### PR DESCRIPTION
- add `xnat_link_data_directory` variable for `xnat` role (defaults to `true`)
- there is already a `xnat_create_data_directory` that if `true` will ensure `xnat_web_server.storage_dir` exists with `tomcat` as the owner, and then creates a symbolic link to `external_storage_drive`
- however, we need to distinguish between creating the data directory and linking to external storage
- if `external_storage_directory` is defined, and is the same path as the XNAT storage directory, then we musn't create and set permissions for this path in the XNAT role. If we did, the mounted storage will have the incorrect permissions
- so, if the `external_storage_drive` is the same path as `xnat_web_server.storage_dir`, then the following values should be set:
```yaml
xnat_create_data_directory: false # don't set permissions for the mounted storage
xnat_link_data_directory: true
```