### PR TITLE
Fix CI tests

### DIFF
--- a/roles/xnat/tasks/configure.yml
+++ b/roles/xnat/tasks/configure.yml
@@ -30,7 +30,6 @@
     timeout: "{{ xnat_wait_for_tomcat | default(0) }}"
   delegate_to: localhost
 
-
 # First, test if the default admin password needs to be changed.
 # To do this, first request a restricted page using the default admin credentials.
 # If this succeeds (200), this is the initial run and the password needs to be changed.

--- a/roles/xnat/tasks/configure.yml
+++ b/roles/xnat/tasks/configure.yml
@@ -22,6 +22,15 @@
 # XNAT initially creates a default admin account with a default password.
 # On the first run, we change the default admin password, then use this account to create a service user, and then disable the default admin account.
 
+# Some times the default admin hasn't finished creating even after tomcat has started
+# Add a delay here to give the admin account a chance to be created
+# Note, this issue only seems to happen in CI
+- name: Wait for Admin account creation
+  ansible.builtin.wait_for:
+    timeout: "{{ xnat_wait_for_tomcat | default(0) }}"
+  delegate_to: localhost
+
+
 # First, test if the default admin password needs to be changed.
 # To do this, first request a restricted page using the default admin credentials.
 # If this succeeds (200), this is the initial run and the password needs to be changed.

--- a/tests/molecule/resources/inventory/group_vars/web.yml
+++ b/tests/molecule/resources/inventory/group_vars/web.yml
@@ -16,3 +16,9 @@ work_zone_ports:
 public_zone_ports:
   - "{{ dicom_port }}"
   - "{{ tomcat_port }}"
+
+# mirsg.xnat.xnat
+# Some times the default admin account hasn't finished creating even after tomcat has started
+# Add a delay here to give the admin account a chance to be created
+# Note, this issue only seems to happen in CI
+xnat_wait_for_tomcat: 10


### PR DESCRIPTION
Fixes #2 

- tests fail in CI, but only some times. For some reason, in CI the default admin account hasn't finished creating even after tomcat has started, causing later tasks to fail
- wait additional 10 seconds for tomcat to start before checking if default admin account exists
