### PR TITLE
Add default variables

### DIFF
--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -1,4 +1,13 @@
 ---
+# Directory on the control node where the Ansible scripts can store files that
+# need to be temporarily cached, such as certificate files that are copied
+# between hosts.
+# You can persist these files between runs to speed up future deployments.
+# In a CI setup, it is best to choose a location that is not within the
+# repository clone, as the files that are created could interfere with the CI's
+# automated checkout and update processes
+ansible_cache_dir: "{{ lookup('env', 'HOME') }}/ansible_persistent_files"
+
 xnat_data_dir: "/data"
 xnat_root_dir: "{{ xnat_data_dir }}/xnat"
 xnat_home_dir: "{{ xnat_root_dir }}/home"

--- a/playbooks/group_vars/web.yml
+++ b/playbooks/group_vars/web.yml
@@ -27,9 +27,9 @@ tomcat_root_webapp: "{{ tomcat_root }}.war"
 tomcat_catalina_home: /usr/share/tomcat
 tomcat_catalina_opts: >-
   -Dxnat.home={{ xnat_home_dir }}
-  -Xms{{ java_mem.Xms }}
-  -Xmx{{ java_mem.Xmx }}
-  -XX:MetaspaceSize={{ java_mem.MetaspaceSize }}
+  -Xms{{ java_mem.Xms | default("512M") }}
+  -Xmx{{ java_mem.Xmx | default("1G") }}
+  -XX:MetaspaceSize={{ java_mem.MetaspaceSize | default("100M") }}
   -XX:+UseG1GC
   -server
 

--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -14,3 +14,14 @@ xnat_logs_dir: "{{ xnat_home_dir }}/logs"
 xnat_work_dir: "{{ xnat_home_dir }}/work"
 xnat_create_data_directory: true
 xnat_link_data_directory: true
+
+# Mail server settings
+xnat_smtp_enabled: false
+xnat_smtp_hostname: ""
+xnat_smtp_port: "2525"
+xnat_smtp_protocol: "smtp"
+xnat_smtp_auth: ""
+xnat_smtp_username: ""
+xnat_smtp_password: ""
+xnat_smtp_start_tls: "false"
+xnat_smtp_ssl_trust: "*"

--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -55,3 +55,6 @@ xnat_plugin_packages: []
 
 # Path to server logo file
 xnat_config_logo: "/images/logo.png" # use the default XNAT logo
+
+# Pipeline engine
+xnat_pipeline_engine_enabled: true

--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -26,6 +26,17 @@ xnat_smtp_password: ""
 xnat_smtp_start_tls: "false"
 xnat_smtp_ssl_trust: "*"
 
+# LDAP configuration
+xnat_ldap_enabled: false
+xnat_ldap_name: ""
+xnat_ldap_address: ""
+xnat_ldap_userdn: ""
+xnat_ldap_password: "{{ vault_ldap_password | default(omit) }}"
+xnat_ldap_base: ""
+xnat_ldap_filter: ""
+xnat_ldap_ca_cert: ""
+xnat_ldap_keystore_alias: ""
+
 # Plugins
 xnat_plugin_urls:
   - "https://api.bitbucket.org/2.0/repositories/xnatdev/xsync/downloads/xsync-plugin-all-1.5.0.jar"

--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -39,14 +39,14 @@ xnat_ldap_keystore_alias: ""
 
 # Plugins
 xnat_plugin_urls:
-  - "https://api.bitbucket.org/2.0/repositories/xnatdev/xsync/downloads/xsync-plugin-all-1.5.0.jar"
+  - "https://api.bitbucket.org/2.0/repositories/xnatdev/xsync/downloads/xsync-plugin-all-1.6.0.jar"
   - "https://api.bitbucket.org/2.0/repositories/xnatx/ldap-auth-plugin/downloads/ldap-auth-plugin-1.1.0.jar"
-  - "https://api.bitbucket.org/2.0/repositories/xnatdev/container-service/downloads/container-service-3.3.0-fat.jar"
+  - "https://api.bitbucket.org/2.0/repositories/xnatdev/container-service/downloads/container-service-3.4.2-fat.jar"
   - "https://api.bitbucket.org/2.0/repositories/xnatx/xnatx-batch-launch-plugin/downloads/batch-launch-0.6.0.jar"
   - "https://github.com/VUIIS/dax/raw/main/misc/xnat-plugins/dax-plugin-genProcData-1.4.2.jar"
-  - "https://api.bitbucket.org/2.0/repositories/icrimaginginformatics/ohif-viewer-xnat-plugin/downloads/ohif-viewer-3.4.1.jar"
+  - "https://api.bitbucket.org/2.0/repositories/icrimaginginformatics/ohif-viewer-xnat-plugin/downloads/ohif-viewer-3.6.1.jar"
   - "https://api.bitbucket.org/2.0/repositories/xnatx/ml-plugin/downloads/ml-plugin-1.0.2.jar"
-  - "https://api.bitbucket.org/2.0/repositories/xnatx/datasets-plugin/downloads/datasets-plugin-1.0.2.jar"
+  - "https://api.bitbucket.org/2.0/repositories/xnatx/datasets-plugin/downloads/datasets-plugin-1.0.3.jar"
   - "https://api.bitbucket.org/2.0/repositories/xnatdev/xnat-image-viewer-plugin/downloads/ximgview-plugin-1.0.2.jar"
   - "https://api.bitbucket.org/2.0/repositories/xnatx/xnatx-dxm-settings-plugin/downloads/dxm-settings-plugin-1.0.jar"
 

--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -52,3 +52,6 @@ xnat_plugin_urls:
 
 xnat_plugin_bundle_urls: []
 xnat_plugin_packages: []
+
+# Path to server logo file
+xnat_config_logo: "/images/logo.png" # use the default XNAT logo

--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -52,6 +52,8 @@ xnat_plugin_urls:
 
 xnat_plugin_bundle_urls: []
 xnat_plugin_packages: []
+xnat_server_specific_plugin_urls: []
+xnat_server_specific_plugin_packages: []
 
 # Path to server logo file
 xnat_config_logo: "/images/logo.png" # use the default XNAT logo

--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -25,3 +25,19 @@ xnat_smtp_username: ""
 xnat_smtp_password: ""
 xnat_smtp_start_tls: "false"
 xnat_smtp_ssl_trust: "*"
+
+# Plugins
+xnat_plugin_urls:
+  - "https://api.bitbucket.org/2.0/repositories/xnatdev/xsync/downloads/xsync-plugin-all-1.5.0.jar"
+  - "https://api.bitbucket.org/2.0/repositories/xnatx/ldap-auth-plugin/downloads/ldap-auth-plugin-1.1.0.jar"
+  - "https://api.bitbucket.org/2.0/repositories/xnatdev/container-service/downloads/container-service-3.3.0-fat.jar"
+  - "https://api.bitbucket.org/2.0/repositories/xnatx/xnatx-batch-launch-plugin/downloads/batch-launch-0.6.0.jar"
+  - "https://github.com/VUIIS/dax/raw/main/misc/xnat-plugins/dax-plugin-genProcData-1.4.2.jar"
+  - "https://api.bitbucket.org/2.0/repositories/icrimaginginformatics/ohif-viewer-xnat-plugin/downloads/ohif-viewer-3.4.1.jar"
+  - "https://api.bitbucket.org/2.0/repositories/xnatx/ml-plugin/downloads/ml-plugin-1.0.2.jar"
+  - "https://api.bitbucket.org/2.0/repositories/xnatx/datasets-plugin/downloads/datasets-plugin-1.0.2.jar"
+  - "https://api.bitbucket.org/2.0/repositories/xnatdev/xnat-image-viewer-plugin/downloads/ximgview-plugin-1.0.2.jar"
+  - "https://api.bitbucket.org/2.0/repositories/xnatx/xnatx-dxm-settings-plugin/downloads/dxm-settings-plugin-1.0.jar"
+
+xnat_plugin_bundle_urls: []
+xnat_plugin_packages: []

--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -22,7 +22,7 @@ xnat_smtp_port: "2525"
 xnat_smtp_protocol: "smtp"
 xnat_smtp_auth: ""
 xnat_smtp_username: ""
-xnat_smtp_password: ""
+xnat_smtp_password: "{{ vault_smtp_password | default(omit) }}"
 xnat_smtp_start_tls: "false"
 xnat_smtp_ssl_trust: "*"
 

--- a/roles/xnat/tasks/ldap.yml
+++ b/roles/xnat/tasks/ldap.yml
@@ -12,7 +12,7 @@
 
 - name: Copy ldap server certificate to client
   ansible.builtin.copy:
-    src: "{{ ldap.ca_cert }}"
+    src: "{{ xnat_ldap_ca_cert }}"
     dest: "{{ ldap_ca_cert_file_on_client }}"
     owner: "{{ xnat.owner }}"
     group: "{{ xnat.group }}"
@@ -41,7 +41,7 @@
     cert_path: "{{ ldap_ca_cert_file_on_client }}"
     keystore_path: "{{ java.keystore_path }}"
     keystore_pass: "{{ java_keystore.keystore_pass }}"
-    cert_alias: "{{ ldap.keystore_alias }}"
+    cert_alias: "{{ xnat_ldap_keystore_alias }}"
     keystore_create: true
     state: present
   notify: Restart tomcat

--- a/roles/xnat/tasks/main.yml
+++ b/roles/xnat/tasks/main.yml
@@ -28,7 +28,7 @@
 
 - name: "Configure LDAP for XNAT"
   ansible.builtin.include_tasks: ldap.yml
-  when: ldap.enabled
+  when: xnat_ldap_enabled
 
 - name: "XNAT site configuration"
   ansible.builtin.include_tasks: configure.yml

--- a/roles/xnat/tasks/main.yml
+++ b/roles/xnat/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: "Add or upgrade pipeline installer"
   ansible.builtin.include_tasks: pipelines.yml
-  when: pipeline_engine_enabled
+  when: xnat_pipeline_engine_enabled
 
 - name: "Configure XNAT settings files"
   ansible.builtin.include_tasks: settings_files.yml

--- a/roles/xnat/templates/ldap1-provider.properties.j2
+++ b/roles/xnat/templates/ldap1-provider.properties.j2
@@ -1,8 +1,8 @@
-name={{ ldap.name }}
+name={{ xnat_ldap_name }}
 provider.id=ldap1
 auth.method=ldap
-address={{ ldap.address }}
-userdn={{ ldap.userdn }}
-password={{ ldap.password }}
-search.base={{ ldap.base }}
-search.filter={{ ldap.filter }}
+address={{ xnat_ldap_address }}
+userdn={{ xnat_ldap_userdn }}
+password={{ xnat_ldap_password }}
+search.base={{ xnat_ldap_base }}
+search.filter={{ xnat_ldap_filter }}

--- a/roles/xnat/templates/prefs-init.j2
+++ b/roles/xnat/templates/prefs-init.j2
@@ -19,16 +19,16 @@ initialized=false
 
 [notifications]
 
-smtpEnabled={{ smtp.enabled }}
-{% if smtp.enabled %}
-smtpHostname={{ smtp.hostname | default("localhost", true) }}
-smtpPort={{ smtp.port }}
-smtpProtocol={{ smtp.protocol }}
-smtpAuth={{ smtp.auth }}
-smtpUsername={{ smtp.username }}
-smtpPassword={{ smtp.password }}
-smtpStartTls={{ smtp.start_tls }}
-smtpSslTrust={{ smtp.ssl_trust }}
+smtpEnabled={{ xnat_smtp_enabled }}
+{% if xnat_smtp_enabled %}
+smtpHostname={{ xnat_smtp_hostname | default("localhost", true) }}
+smtpPort={{ xnat_smtp_port }}
+smtpProtocol={{ xnat_smtp_protocol }}
+smtpAuth={{ xnat_smtp_auth }}
+smtpUsername={{ xnat_smtp_username }}
+smtpPassword={{ xnat_smtp_password }}
+smtpStartTls={{ xnat_smtp_start_tls }}
+smtpSslTrust={{ xnat_smtp_ssl_trust }}
 
 emailPrefix={{ xnat_config.site_name }}
 {% endif %}

--- a/tests/molecule/resources/inventory/group_vars/all/all.yml
+++ b/tests/molecule/resources/inventory/group_vars/all/all.yml
@@ -9,9 +9,6 @@ diffie_helman_size_bits: 2048
 # Support for ipv6
 ipv6_enabled: false
 
-# Locale for the servers
-server_locale: "en_GB.UTF-8"
-
 # Mail server settings
 smtp:
   enabled: false

--- a/tests/molecule/resources/inventory/group_vars/all/all.yml
+++ b/tests/molecule/resources/inventory/group_vars/all/all.yml
@@ -9,18 +9,6 @@ nginx_diffie_helman_size_bits: 2048
 # Support for ipv6
 ipv6_enabled: false
 
-# Mail server settings
-smtp:
-  enabled: false
-  hostname: "192.168.56.101"
-  port: "2525"
-  protocol: "smtp"
-  auth: ""
-  username: ""
-  password: "{{ vault_smtp_password }}"
-  start_tls: "false"
-  ssl_trust: "*"
-
 # XNAT configuration shared between all servers
 xnat_common_config:
   admin_email: "xnatadmin@{{ hostvars['xnat_web']['hostname'] }}"

--- a/tests/molecule/resources/inventory/group_vars/all/all.yml
+++ b/tests/molecule/resources/inventory/group_vars/all/all.yml
@@ -1,13 +1,4 @@
 ---
-# Directory on the control node where the Ansible scripts can store files that
-# need to be temporarily cached, such as certificate files that are copied
-# between hosts.
-# You can persist these files between runs to speed up future deployments.
-# In a CI setup, it is best to choose a location that is not within the
-# repository clone, as the files that are created could interfere with the CI's
-# automated checkout and update processes
-ansible_cache_dir: "{{ lookup('env', 'HOME') }}/ansible_persistent_files"
-
 # Bit size for OpenSSL Diffie-Hellman Parameters. Higher bit sizes are more
 # secure, but require exponentially larger times for the one-off parameter
 # generation. Use 4096 for production. These may take 10mins+ to generate but

--- a/tests/molecule/resources/inventory/group_vars/all/all.yml
+++ b/tests/molecule/resources/inventory/group_vars/all/all.yml
@@ -4,7 +4,7 @@
 # generation. Use 4096 for production. These may take 10mins+ to generate but
 # are only generated once per server.
 # For local testing (non-production), use 2096 to speed up deployment.
-nginx_diffie_helman_size_bits: 2048
+diffie_helman_size_bits: 2048
 
 # Support for ipv6
 ipv6_enabled: false

--- a/tests/molecule/resources/inventory/group_vars/all/all.yml
+++ b/tests/molecule/resources/inventory/group_vars/all/all.yml
@@ -4,7 +4,7 @@
 # generation. Use 4096 for production. These may take 10mins+ to generate but
 # are only generated once per server.
 # For local testing (non-production), use 2096 to speed up deployment.
-diffie_helman_size_bits: 2048
+nginx_diffie_helman_size_bits: 2048
 
 # Support for ipv6
 ipv6_enabled: false

--- a/tests/molecule/resources/inventory/group_vars/all/common.yml
+++ b/tests/molecule/resources/inventory/group_vars/all/common.yml
@@ -11,6 +11,9 @@ postgresql_use_ssl: true
 # Set this to true if selinux is enabled on the hosting OS
 selinux_enabled: false
 
+# XNAT supports PostgreSQL 11-14
+postgresql_version: "12"
+
 java_keystore:
   keystore_pass: "{{ vault_keystore_password }}"
 

--- a/tests/molecule/resources/inventory/group_vars/all/common.yml
+++ b/tests/molecule/resources/inventory/group_vars/all/common.yml
@@ -18,5 +18,3 @@ java_keystore:
 # defined in a string, or extracted from a template file e.g. using
 # lookup('template, 'foo.j2') | to_json
 xnat_sitewide_anonymization_script: "{{ xnat_common_config.sitewideAnonymizationScript | to_json }}"
-
-pipeline_engine_enabled: false

--- a/tests/molecule/resources/inventory/group_vars/all/common.yml
+++ b/tests/molecule/resources/inventory/group_vars/all/common.yml
@@ -26,9 +26,6 @@ postgresql_use_ssl: true
 # Set this to true if selinux is enabled on the hosting OS
 selinux_enabled: false
 
-# XNAT supports PostgreSQL 11-14
-postgresql_version: "12"
-
 java_keystore:
   keystore_pass: "{{ vault_keystore_password }}"
 

--- a/tests/molecule/resources/inventory/group_vars/all/common.yml
+++ b/tests/molecule/resources/inventory/group_vars/all/common.yml
@@ -1,20 +1,5 @@
 ---
 # xnat
-xnat_plugin_urls:
-  - "https://api.bitbucket.org/2.0/repositories/xnatdev/xsync/downloads/xsync-plugin-all-1.5.0.jar"
-  - "https://api.bitbucket.org/2.0/repositories/xnatx/ldap-auth-plugin/downloads/ldap-auth-plugin-1.1.0.jar"
-  - "https://api.bitbucket.org/2.0/repositories/xnatdev/container-service/downloads/container-service-3.3.0-fat.jar"
-  - "https://api.bitbucket.org/2.0/repositories/xnatx/xnatx-batch-launch-plugin/downloads/batch-launch-0.6.0.jar"
-  - "https://github.com/VUIIS/dax/raw/main/misc/xnat-plugins/dax-plugin-genProcData-1.4.2.jar"
-  - "https://api.bitbucket.org/2.0/repositories/icrimaginginformatics/ohif-viewer-xnat-plugin/downloads/ohif-viewer-3.4.1.jar"
-  - "https://api.bitbucket.org/2.0/repositories/xnatx/ml-plugin/downloads/ml-plugin-1.0.2.jar"
-  - "https://api.bitbucket.org/2.0/repositories/xnatx/datasets-plugin/downloads/datasets-plugin-1.0.2.jar"
-  - "https://api.bitbucket.org/2.0/repositories/xnatdev/xnat-image-viewer-plugin/downloads/ximgview-plugin-1.0.2.jar"
-  - "https://api.bitbucket.org/2.0/repositories/xnatx/xnatx-dxm-settings-plugin/downloads/dxm-settings-plugin-1.0.jar"
-
-xnat_plugin_bundle_urls: []
-xnat_plugin_packages: []
-
 package_registry:
   enabled: false
   url: ""

--- a/tests/molecule/resources/inventory/group_vars/all/common.yml
+++ b/tests/molecule/resources/inventory/group_vars/all/common.yml
@@ -14,9 +14,6 @@ selinux_enabled: false
 java_keystore:
   keystore_pass: "{{ vault_keystore_password }}"
 
-# Path to server logo file
-xnat_config_logo: "/images/logo.png" # use the default XNAT logo
-
 # JSON representation of the site-wide anonymisation script: this could be
 # defined in a string, or extracted from a template file e.g. using
 # lookup('template, 'foo.j2') | to_json

--- a/tests/molecule/resources/inventory/group_vars/all/common.yml
+++ b/tests/molecule/resources/inventory/group_vars/all/common.yml
@@ -14,18 +14,6 @@ selinux_enabled: false
 java_keystore:
   keystore_pass: "{{ vault_keystore_password }}"
 
-# LDAP configuration
-ldap:
-  enabled: false
-  name: ""
-  address: ""
-  userdn: ""
-  password: "{{ vault_ldap_password }}"
-  base: ""
-  filter: ""
-  ca_cert: ""
-  keystore_alias: ""
-
 # Path to server logo file
 xnat_config_logo: "/images/logo.png" # use the default XNAT logo
 

--- a/tests/molecule/resources/inventory/group_vars/all/common.yml
+++ b/tests/molecule/resources/inventory/group_vars/all/common.yml
@@ -34,10 +34,4 @@ xnat_config_logo: "/images/logo.png" # use the default XNAT logo
 # lookup('template, 'foo.j2') | to_json
 xnat_sitewide_anonymization_script: "{{ xnat_common_config.sitewideAnonymizationScript | to_json }}"
 
-# You may want to increase the heap space if you have enough RAM available
-java_mem:
-  Xms: "512M"
-  Xmx: "1G"
-  MetaspaceSize: "100M"
-
 pipeline_engine_enabled: false

--- a/tests/molecule/resources/inventory/group_vars/all/server.yml
+++ b/tests/molecule/resources/inventory/group_vars/all/server.yml
@@ -40,9 +40,5 @@ xnat_config:
   site_description: "<h1>MIRSG XNAT</h1><p>A test instance of XNAT."
   admin_password: "{{ vault_admin_password }}"
 
-# Configuration for XNAT Container Service
-container_service_enabled: false
-container_service_remote_xnat_root: ""
-
 # Configuration for montoring service
 monitoring_service_enabled: false

--- a/tests/molecule/resources/inventory/group_vars/all/server.yml
+++ b/tests/molecule/resources/inventory/group_vars/all/server.yml
@@ -21,10 +21,6 @@ xnat_db:
   data_dir: "{{ external_storage_drive }}/pgsql/{{ postgresql_version }}/data"
   backups_dir: "{{ external_storage_drive }}/pgsql/backups"
 
-# XNAT plugins
-xnat_server_specific_plugin_urls: []
-xnat_server_specific_plugin_packages: []
-
 # SSL certificate settings
 ssl:
   use_ssl: false


### PR DESCRIPTION
Fixes #12 

- add some defaults to `mirsr.infrastructure.xnat` that currently need to be defined as group vars. These defaults use flat naming rather than nested, and are prefixed with the role name
- remove `server_locale` from test inventory group vars as it is the same as the default in `mirsg.infrastructure.provision`
- set defaults for the `java_mem` variable
- add `ansible_cache_dir` as a playbook group var so we don't need to define it at the inventory level
- there are other variables that could be made defaults in a separate PR but they are less straightforward for a couple of reasons:
  - they are used in multiple roles
  - they are used in the `mirsg.infrastructure` collection (and so should be defined as defaults in the relevant roles there)