### PR TITLE
Update postgres RPM GPG key

### DIFF
--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -15,7 +15,7 @@ xnat_home_dir: "{{ xnat_root_dir }}/home"
 database_server_certificate_cache_filename: "{{ ansible_cache_dir }}/pg_certificates/{{ xnat_db.host }}.pg.server.crt"
 database_client_certificate_cache_filename: "{{ ansible_cache_dir }}/pg_certificates/{{ xnat_db.host }}.pg.client.crt"
 
-postgresql_rpm_gpg_key_pgdg: "https://www.postgresql.org/download/keys/RPM-GPG-KEY-PGDG"
+postgresql_rpm_gpg_key_pgdg: "https://apt.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL"
 
 # mirsg.infrastructure.postgresql - download and install - we need to do this on both the web server and the db
 postgresql_install:


### PR DESCRIPTION
Fixes #16 

- the GPG key for the latest version of the postgres RPM has moved to a new location - update `postgresql_rpm_gpg_key_pgdg` to reflect this