### PR TITLE
Handle both intel & ARM RPM key

### DIFF
--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -7,4 +7,4 @@ collections:
   - community.crypto
   - name: https://github.com/UCL-MIRSG/ansible-collection-infra.git
     type: git
-    version: main
+    version: 1.3.0

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -15,11 +15,6 @@ xnat_home_dir: "{{ xnat_root_dir }}/home"
 database_server_certificate_cache_filename: "{{ ansible_cache_dir }}/pg_certificates/{{ xnat_db.host }}.pg.server.crt"
 database_client_certificate_cache_filename: "{{ ansible_cache_dir }}/pg_certificates/{{ xnat_db.host }}.pg.client.crt"
 
-postgresql_rpm_gpg_key_pgdg:
-  x86_64: >-
-    https://apt.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL
-  aarch64: >-
-    https://apt.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-AARCH64-RHEL
 
 # mirsg.infrastructure.postgresql - download and install - we need to do this on both the web server and the db
 postgresql_install:

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -15,7 +15,11 @@ xnat_home_dir: "{{ xnat_root_dir }}/home"
 database_server_certificate_cache_filename: "{{ ansible_cache_dir }}/pg_certificates/{{ xnat_db.host }}.pg.server.crt"
 database_client_certificate_cache_filename: "{{ ansible_cache_dir }}/pg_certificates/{{ xnat_db.host }}.pg.client.crt"
 
-postgresql_rpm_gpg_key_pgdg: "https://apt.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL"
+postgresql_rpm_gpg_key_pgdg:
+  x86_64: >-
+    https://apt.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL
+  aarch64: >-
+    https://apt.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-AARCH64-RHEL
 
 # mirsg.infrastructure.postgresql - download and install - we need to do this on both the web server and the db
 postgresql_install:

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -15,7 +15,6 @@ xnat_home_dir: "{{ xnat_root_dir }}/home"
 database_server_certificate_cache_filename: "{{ ansible_cache_dir }}/pg_certificates/{{ xnat_db.host }}.pg.server.crt"
 database_client_certificate_cache_filename: "{{ ansible_cache_dir }}/pg_certificates/{{ xnat_db.host }}.pg.client.crt"
 
-
 # mirsg.infrastructure.postgresql - download and install - we need to do this on both the web server and the db
 postgresql_install:
   disable_gpg_check: false

--- a/tests/molecule/resources/inventory/group_vars/web.yml
+++ b/tests/molecule/resources/inventory/group_vars/web.yml
@@ -21,4 +21,4 @@ public_zone_ports:
 # Some times the default admin account hasn't finished creating even after tomcat has started
 # Add a delay here to give the admin account a chance to be created
 # Note, this issue only seems to happen in CI
-xnat_wait_for_tomcat: 10
+xnat_wait_for_tomcat: 15


### PR DESCRIPTION
There might be a better way, but due to the naming convention of keys https://apt.postgresql.org/pub/repos/yum/keys. Not sure how else to do it? I will raise a PR to update https://github.com/UCL-MIRSG/ansible-collection-infra.