### PR TITLE
firewalld var name prefix

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,7 +16,6 @@ readme: README.md
 # A list of the collection's content authors. Can be just the name or in the format 'Full Name <email> (url)
 # @nicks:irc/im.site#channel'
 authors:
-  - Daniel Matthews <d.matthews@ucl.ac.uk>
   - MIRSG (github.com/UCL-MIRSG)
 
 ### OPTIONAL but strongly recommended
@@ -48,10 +47,10 @@ dependencies:
   "community.crypto": ">=2.14.1"
 
 # The URL of the originating SCM repository
-repository: https://github.com/UCL-MIRSG/ansible-collection-xnatinstaller
+repository: https://github.com/UCL-MIRSG/ansible-collection-xnat
 
 # The URL to the collection issue tracker
-issues: https://github.com/UCL-MIRSG/ansible-collection-xnatinstaller/issues
+issues: https://github.com/UCL-MIRSG/ansible-collection-xnat/issues
 
 # A list of file glob-like patterns used to filter any files or directories that should not be included in the build
 # artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This

--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -7,4 +7,4 @@ collections:
   - community.crypto
   - name: https://github.com/UCL-MIRSG/ansible-collection-infra.git
     type: git
-    version: 1.3.0
+    version: main

--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -7,4 +7,4 @@ collections:
   - community.crypto
   - name: https://github.com/UCL-MIRSG/ansible-collection-infra.git
     type: git
-    version: main
+    version: 1.3.0

--- a/tests/molecule/resources/inventory/group_vars/db.yml
+++ b/tests/molecule/resources/inventory/group_vars/db.yml
@@ -1,7 +1,7 @@
 ---
 # mirsg.infrastructure.firewalld
-internal_zone_sources:
+firewalld_internal_zone_sources:
   - "{{ xnat_web_server.subnet | default(xnat_web_server.ip + '/32') }}"
 
-internal_zone_open_services:
+firewalld_internal_zone_open_services:
   - "postgresql"


### PR DESCRIPTION
Changes:

- Update variable names for the `firewalld` role in the molecule tests
- Update some details in `galaxy.yml`

After https://github.com/UCL-MIRSG/ansible-collection-infra/pull/35 is merged I propose creating a new release of the `mirsg.infrastructure` collection (`1.3.0`) and pinning the version number in [meta/requirements.yml](https://github.com/UCL-MIRSG/ansible-collection-xnat/blob/33413301671dcca18388f13a91ec363c9ce07539/meta/requirements.yml#L10) in this PR.